### PR TITLE
[joona95] 2주차 과제 제출

### DIFF
--- a/02주차/10422/10422_java_joona95.java
+++ b/02주차/10422/10422_java_joona95.java
@@ -1,0 +1,46 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class Main {
+
+    public long solution(int l) {
+
+        if (l % 2 != 0) {
+            return 0;
+        }
+
+        long[] dp = new long[l + 1];
+        dp[0] = 1;
+        dp[1] = 1;
+        for (int i = 2; i <= l / 2; i++) {
+            for (int j = 1; j <= i; j++) {
+                dp[i] = (dp[i] + dp[i - j] * dp[j - 1]) % 1000000007;
+            }
+        }
+
+        return dp[l / 2];
+    }
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        Main main = new Main();
+
+        int t = Integer.parseInt(br.readLine());
+        for (int i = 0; i < t; i++) {
+            int l = Integer.parseInt(br.readLine());
+            long answer = main.solution(l);
+            bw.write(answer + "\n");
+        }
+
+        bw.flush();
+
+        br.close();
+        bw.close();
+    }
+}

--- a/02주차/10422/10422_java_joona95.java
+++ b/02주차/10422/10422_java_joona95.java
@@ -6,22 +6,21 @@ import java.io.OutputStreamWriter;
 
 public class Main {
 
-    public long solution(int l) {
+    public static int MAX = 5000;
+    public static int MOD = 1_000_000_007;
+    public static long[] dp;
 
-        if (l % 2 != 0) {
-            return 0;
-        }
+    public void initDP() {
 
-        long[] dp = new long[l + 1];
+        dp = new long[MAX + 1];
         dp[0] = 1;
         dp[1] = 1;
-        for (int i = 2; i <= l / 2; i++) {
+
+        for (int i = 2; i <= MAX / 2; i++) {
             for (int j = 1; j <= i; j++) {
-                dp[i] = (dp[i] + dp[i - j] * dp[j - 1]) % 1000000007;
+                dp[i] = (dp[i] + dp[i - j] * dp[j - 1]) % MOD;
             }
         }
-
-        return dp[l / 2];
     }
 
     public static void main(String[] args) throws IOException {
@@ -31,10 +30,12 @@ public class Main {
 
         Main main = new Main();
 
+        main.initDP();
+
         int t = Integer.parseInt(br.readLine());
         for (int i = 0; i < t; i++) {
             int l = Integer.parseInt(br.readLine());
-            long answer = main.solution(l);
+            long answer = l % 2 == 0 ? dp[l / 2] : 0L;
             bw.write(answer + "\n");
         }
 

--- a/02주차/10422/10422_java_joona95.java
+++ b/02주차/10422/10422_java_joona95.java
@@ -12,7 +12,7 @@ public class Main {
 
     public void initDP() {
 
-        dp = new long[MAX + 1];
+        dp = new long[MAX / 2 + 1];
         dp[0] = 1;
         dp[1] = 1;
 

--- a/02주차/11052/11052_java_joona95.java
+++ b/02주차/11052/11052_java_joona95.java
@@ -1,0 +1,45 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    public int solution(int n, int[] arr) {
+
+        int[] dp = new int[n + 1];
+        for (int i = 1; i <= n; i++) {
+            dp[i] = arr[i];
+            for (int j = i; j >= i / 2; j--) {
+                dp[i] = Math.max(dp[j] + dp[i - j], dp[i]);
+            }
+        }
+
+        return dp[n];
+    }
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        Main main = new Main();
+
+        int n = Integer.parseInt(br.readLine());
+        int[] arr = new int[n + 1];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int answer = main.solution(n, arr);
+
+        bw.write(String.valueOf(answer));
+        bw.flush();
+
+        br.close();
+        bw.close();
+    }
+}

--- a/02주차/11055/11055_java_joona95.java
+++ b/02주차/11055/11055_java_joona95.java
@@ -1,0 +1,52 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    public int solution(int n, int[] arr) {
+
+        int[] dp = new int[n];
+        dp[0] = arr[0];
+        for (int i = 1; i < n; i++) {
+            dp[i] = arr[i];
+            for (int j = 1; j <= i; j++) {
+                if (arr[i] > arr[i - j]) {
+                    dp[i] = Math.max(dp[i - j] + arr[i], dp[i]);
+                }
+            }
+        }
+
+        int max = Integer.MIN_VALUE;
+        for (int i = 0; i < n; i++) {
+            max = Math.max(max, dp[i]);
+        }
+        return max;
+    }
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        Main main = new Main();
+
+        int n = Integer.parseInt(br.readLine());
+        int[] arr = new int[n];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int answer = main.solution(n, arr);
+
+        bw.write(String.valueOf(answer));
+        bw.flush();
+
+        br.close();
+        bw.close();
+    }
+}


### PR DESCRIPTION
## 11055
- dp 배열 내에 해당 인덱스까지 증가하는 수열의 합 중 최대값을 저장
- 입력받은 arr 배열 인덱스를 돌면서 해당 배열값보다 작은 경우에만 합 최대값 갱신 
- 시간복잡도 : O(N*N) 
  - N : 배열의 길이 <= 1000

## 11052
- dp 배열 내에 카드 N개 구매 가격 최대값을 저장
- N장을 구매하기 위해  A장 구매 가격 + (N - A)장 구매 가격의 합을 비교하면서 최대값 갱신 
- 시간복잡도 : O(N*N) 
  - N : 카드 장 수 <= 1000

## 10422
- 1000000007 나머지 값을 배열에 저장
- 길이가 홀수인 경우에는 올바른 괄호를 만들 수 없으므로 0 리턴
- dp 배열에 N개의 괄호로 만들 수 있는 올바른 괄호의 갯수 저장
    - dp[N - 1] * dp[0] + dp[N - 2] * dp[1] + … +  dp[1] * dp[N-2] + dp[0] * dp[N-1]
    - N개의 괄호가 있을 때 괄호 하나 () 를 두고, 괄호 안에 A 개의 괄호를 넣는다고 하면 괄호 밖에 (N - 1 - A) 개의 괄호를 넣을 수 있음
    - 예) 4개의 괄호로 만들 수 있는 올바른 괄호의 갯수  : dp[3] * dp[0] + dp[2] * dp[1] + dp[1] * dp[2] + dp[0] * dp[3] = 14
        - 3개의 괄호로 만들 수 있는 경우의 수 : (()()) / ((())) / (())() / ()(())  / ()()() = dp[2] * dp[0] + dp[1] * dp[1] + dp[0] * dp[2] = 5
        - 2개의 괄호로 만들 수 있는 경우의 수 : (()) / ()() = dp[1] * dp[0] + dp[0] * dp[1] = 2
        - 1개의 괄호로 만들 수 있는 경우의 수 : () = 1
        - 0개의 괄호로 만들 수 있는 경우의 수 :  1
- 카탈란 수 알고리즘
- 시간복잡도 : O(T\*N\*N) 
  - T : 테스트케이스 수 <= 100
  - N : 괄호 수 <= 2500 (홀수를 제외)