### PR TITLE
[haonmik1] 2주차 과제 제출

### DIFF
--- a/02주차/10422/10422_java_noah.java
+++ b/02주차/10422/10422_java_noah.java
@@ -1,0 +1,28 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        
+        for (int t = 0; t < T; t++) {
+            int L = Integer.parseInt(br.readLine());
+            if (L % 2 == 1) { 
+                System.out.println(0); 
+                continue; 
+            }
+            
+            long[] dp = new long[L/2 + 1];
+            dp[0] = 1;
+            
+            for (int i = 1; i <= L/2; i++) {
+                for (int j = 0; j < i; j++) {
+                    dp[i] = (dp[i] + dp[j] * dp[i-1-j]) % 1000000007;
+                }
+            }
+            
+            System.out.println(dp[L / 2]);
+        }
+    }   
+}

--- a/02주차/11052/11052_java_noah.java
+++ b/02주차/11052/11052_java_noah.java
@@ -1,0 +1,25 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int[] arr = new int[n+1];
+        int[] dp = new int[n+1];
+        
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        for (int i = 1; i <= n; i++) {        
+            for (int j = 1; j <= i; j++) {    
+                dp[i] = Math.max(dp[i], dp[i - j] + arr[j]);
+            }
+        }
+        
+        System.out.println(dp[n]);
+    }
+}

--- a/02주차/11055/11055_java_noah.java
+++ b/02주차/11055/11055_java_noah.java
@@ -1,0 +1,31 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int[] arr = new int[n];
+        int[] dp = new int[n];
+        
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+            dp[i] = arr[i]; 
+        }
+
+        int maxSum = arr[0];
+        
+        for (int i = 1; i < n; i++) {
+            for (int j = 0; j < i; j++) {
+                if (arr[j] < arr[i]) {
+                    dp[i] = Math.max(dp[i], dp[j] + arr[i]);
+                }
+            }
+            maxSum = Math.max(maxSum, dp[i]);
+        }
+        
+        System.out.println(maxSum);
+    }
+}


### PR DESCRIPTION
# 11052 - 카드 구매하기
* 시간복잡도: O(N²)
* dp[i] = i개 카드의 최대 금액
* 1부터 i까지 순회하며 j개 카드팩을 샀을 때 dp[i-j] + arr[j]의 최대값을 구하는 방식으로 풀었습니다.

# 11055 - 가장 큰 증가 부분 수열
* 시간복잡도: O(N²)
* dp[i] = i번째까지 증가 부분 수열의 최대 합
* arr[j] < arr[i]인 경우 dp[j] + arr[i]의 최대값을 구하고, 전체 dp 중 최대값을 찾는 방식으로 풀었습니다.

# 10422 - 괄호
* 시간복잡도: O(T × N²)
* dp[i] = 길이 2i인 올바른 괄호 문자열 개수
* 카탈란 수를 적용하여 (내부괄호) + 나머지괄호 형태로 분해해서 dp[j] × dp[i-1-j]를 합산하는 방식으로 풀었습니다. 입력마다 계산.


